### PR TITLE
Introduce ifAggregateExists middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 # OS generated files and folders
 .DS_Store
 npm-debug.log
+
+# IntelliJ IDEA project files
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -221,6 +221,49 @@ const commands = {
 };
 ```
 
+#### only.ifAggregateExists
+
+This middleware passes if the requested related aggregate exists, otherwise it rejects the command. 
+
+It accepts the following parameters in an object as a single argument:
+
+* `context`: the name of the context the related aggregate belongs
+* `aggregate`: the name of the related aggregate
+* `options`: 
+  * `rejectWhenMissingId` (default: `false`): Rejects the command if the provider function does not return a value.
+    Default behaviour allows to pass through if the relation is optional.
+
+* `provider`: function to extract the id of the related aggregate 
+  
+  Receives as arguments:
+  
+  * `aggregateInstance`: the current aggregate
+  * `command`: the command
+  * `services`: the services injected in a middleware
+  
+  Returns: the identifier of the related aggregate 
+
+*Please note that due to the eventual consistency of the system you cannot 100% guarantee that
+the aggregate effectively exists.*
+
+```javascript
+const commands = {
+  send: [
+    only.ifAggregateExists({ 
+      context: 'planning', 
+      aggregate: 'initiator', 
+      provider(message, command, services) {
+         return command.data.initiator; // provides the id of the aggregate to check
+      },
+      options: { rejectWhenMissingId: true } // Rejects the command when the provider cannot extract an id.
+    }),
+    async (peerGroup, command) => {
+      // ...
+    }
+  ]
+}
+```
+
 ## Running the build
 
 To build this module use [roboter](https://www.npmjs.com/package/roboter).

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ It accepts the following parameters in an object as a single argument:
 * `aggregate`: the name of the related aggregate
 * `options`: 
   * `rejectWhenMissingId` (default: `false`): Rejects the command if the provider function does not return a value.
-    Default behaviour allows to pass through if the relation is optional.
+    Default behaviour passes through if the relation is optional.
 
 * `provider`: function to extract the id of the related aggregate 
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,7 +2688,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2709,12 +2710,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2729,17 +2732,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2856,7 +2862,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2868,6 +2875,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2882,6 +2890,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2889,12 +2898,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2913,6 +2924,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2993,7 +3005,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3005,6 +3018,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3090,7 +3104,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3126,6 +3141,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3145,6 +3161,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3188,12 +3205,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     {
       "name": "Jan-Hendrik Grundhöfer",
       "email": "jan-hendrik.grundhoefer@thenativeweb.io"
+    },
+    {
+      "name": "Damien Benon",
+      "email": "damien.benon@myprysm.fr"
     }
   ],
   "main": "dist/index.js",

--- a/src/only.js
+++ b/src/only.js
@@ -107,7 +107,7 @@ only.ifStateValidatedBy = function (schema) {
 
 only.ifAggregateExists = function ({ context, aggregate, provider, options = { rejectWhenMissingId: false }}) {
   if (typeof context !== 'string') {
-    throw new Error('Domain name must be a string.');
+    throw new Error('Context name must be a string.');
   }
   if (typeof aggregate !== 'string') {
     throw new Error('Aggregate name must be a string.');

--- a/src/only.js
+++ b/src/only.js
@@ -105,7 +105,7 @@ only.ifStateValidatedBy = function (schema) {
   };
 };
 
-only.ifAggregateExists = function ({ context, aggregate, provider, options = { rejectWhenMissingId: false } }) {
+only.ifAggregateExists = function ({ context, aggregate, provider, options = { rejectWhenMissingId: false }}) {
   if (typeof context !== 'string') {
     throw new Error('Domain name must be a string.');
   }
@@ -132,6 +132,7 @@ only.ifAggregateExists = function ({ context, aggregate, provider, options = { r
     }
 
     let id;
+
     try {
       id = provider(instance, command, services);
     } catch (err) {
@@ -147,7 +148,7 @@ only.ifAggregateExists = function ({ context, aggregate, provider, options = { r
     } catch (err) {
       command.reject(err.message);
     }
-  }
+  };
 };
 
 module.exports = only;

--- a/test/units/onlyTests.js
+++ b/test/units/onlyTests.js
@@ -494,4 +494,172 @@ suite('only', () => {
       });
     });
   });
+
+  suite('ifAggregateExists', () => {
+    const context = 'context';
+    const aggregate = 'aggregate';
+    const defaultCommand = {
+      reject(reason) {
+        throw new Error(reason);
+      }
+    }
+
+    test('is a function.', async () => {
+      assert.that(only.ifAggregateExists).is.ofType('function');
+    });
+
+    test('throws an error if context is missing.', async () => {
+      assert.that(() => {
+        only.ifAggregateExists({});
+      }).is.throwing('Domain name must be a string.');
+    });
+
+    test('throws an error if aggregate is missing.', async () => {
+      assert.that(() => {
+        only.ifAggregateExists({ context });
+      }).is.throwing('Aggregate name must be a string.');
+    });
+
+    test('throws an error if provider is not a function.', async () => {
+      assert.that(() => {
+        only.ifAggregateExists({ context, aggregate, provider: 'provider' });
+      }).is.throwing('Id provider must be a function.');
+    });
+
+    test('throws an error if options is not an object.', async () => {
+      const provider = () => true;
+      const options = 'some string';
+
+      assert.that(() => {
+        only.ifAggregateExists({ context, aggregate, provider, options });
+      }).is.throwing('Options must be an object.');
+    });
+
+    suite('instance', () => {
+      let ifAggregateExists;
+
+      setup(() => {
+        ifAggregateExists = only.ifAggregateExists({
+          context,
+          aggregate,
+          provider(_, command) {
+            return command.data.id;
+          }
+        });
+      });
+
+      test('is a function.', async () => {
+        assert.that(ifAggregateExists).is.ofType('function');
+      });
+
+      test('throws an error when context does not exist', async () => {
+        const services = {
+          app: {}
+        };
+
+        assert.that(async () => {
+          await ifAggregateExists({}, defaultCommand, services);
+        }).is.throwingAsync('context does not exist.');
+      });
+
+      test('throws an error when aggregate does not exist', async () => {
+        const services = {
+          app: {
+            context: {}
+          }
+        };
+
+        assert.that(async () => {
+          await ifAggregateExists({}, defaultCommand, services);
+        }).is.throwingAsync('context.aggregate does not exist.');
+      });
+
+      test('throws an error when id provider fails to extract id', async () => {
+        const services = {
+          app: {
+            context: {
+              aggregate(id) {
+              }
+            }
+          }
+        };
+
+        assert.that(async () => {
+          await ifAggregateExists({}, defaultCommand, services);
+        }).is.throwingAsync('Unable to extract aggregate id: Cannot read property \'id\' of undefined');
+      });
+
+      test('throws an error when it should reject on missing id and no id is extracted', async () => {
+        const services = {
+          app: {
+            context: {
+              aggregate(id) {
+              }
+            }
+          }
+        };
+
+        const ifAggregateExistsRejectWhenMissingId = only.ifAggregateExists({
+          context,
+          aggregate,
+          provider(_, command) {
+            return command.data.id;
+          },
+          options: { rejectWhenMissingId: true }
+        });
+
+        const command = {
+          ...defaultCommand,
+          data: {}
+        }
+
+        assert.that(async () => {
+          await ifAggregateExistsRejectWhenMissingId({}, command, services);
+        }).is.throwingAsync('Unable to extract aggregate id');
+      });
+
+      test('throws an error when reading aggregate fails', async () => {
+        const services = {
+          app: {
+            context: {
+              aggregate: () => ({
+                read() {
+                  throw new Error('Aggregate not found.');
+                }
+              })
+            }
+          }
+        };
+
+        const command = {
+          ...defaultCommand,
+          data: { id: 'some-id' }
+        };
+
+        assert.that(async () => {
+          await ifAggregateExists({}, command, services);
+        }).is.throwingAsync('Aggregate not found.')
+      });
+
+      test('passes when read succeeds', async () => {
+        const services = {
+          app: {
+            context: {
+              aggregate: () => ({
+                async read() {
+                }
+              })
+            }
+          }
+        };
+
+        const command = {
+          ...defaultCommand,
+          data: { id: 'some-id' }
+        };
+
+        await ifAggregateExists({}, command, services);
+      });
+    });
+  });
 });

--- a/test/units/onlyTests.js
+++ b/test/units/onlyTests.js
@@ -661,6 +661,27 @@ suite('only', () => {
 
         await ifAggregateExists({}, command, services);
       });
+
+      test('passes when relation is optional', async () => {
+        const services = {
+          app: {
+            context: {
+              aggregate: () => ({
+                read () {
+                  return Promise.resolve();
+                }
+              })
+            }
+          }
+        };
+
+        const command = {
+          ...defaultCommand,
+          data: {}
+        };
+
+        await ifAggregateExists({}, command, services);
+      });
     });
   });
 });

--- a/test/units/onlyTests.js
+++ b/test/units/onlyTests.js
@@ -499,10 +499,10 @@ suite('only', () => {
     const context = 'context';
     const aggregate = 'aggregate';
     const defaultCommand = {
-      reject(reason) {
+      reject (reason) {
         throw new Error(reason);
       }
-    }
+    };
 
     test('is a function.', async () => {
       assert.that(only.ifAggregateExists).is.ofType('function');
@@ -542,7 +542,7 @@ suite('only', () => {
         ifAggregateExists = only.ifAggregateExists({
           context,
           aggregate,
-          provider(_, command) {
+          provider (_, command) {
             return command.data.id;
           }
         });
@@ -578,7 +578,7 @@ suite('only', () => {
         const services = {
           app: {
             context: {
-              aggregate(id) {
+              aggregate () {
               }
             }
           }
@@ -593,7 +593,7 @@ suite('only', () => {
         const services = {
           app: {
             context: {
-              aggregate(id) {
+              aggregate () {
               }
             }
           }
@@ -602,7 +602,7 @@ suite('only', () => {
         const ifAggregateExistsRejectWhenMissingId = only.ifAggregateExists({
           context,
           aggregate,
-          provider(_, command) {
+          provider (_, command) {
             return command.data.id;
           },
           options: { rejectWhenMissingId: true }
@@ -611,7 +611,7 @@ suite('only', () => {
         const command = {
           ...defaultCommand,
           data: {}
-        }
+        };
 
         assert.that(async () => {
           await ifAggregateExistsRejectWhenMissingId({}, command, services);
@@ -623,7 +623,7 @@ suite('only', () => {
           app: {
             context: {
               aggregate: () => ({
-                read() {
+                read () {
                   throw new Error('Aggregate not found.');
                 }
               })
@@ -638,7 +638,7 @@ suite('only', () => {
 
         assert.that(async () => {
           await ifAggregateExists({}, command, services);
-        }).is.throwingAsync('Aggregate not found.')
+        }).is.throwingAsync('Aggregate not found.');
       });
 
       test('passes when read succeeds', async () => {
@@ -646,7 +646,8 @@ suite('only', () => {
           app: {
             context: {
               aggregate: () => ({
-                async read() {
+                read () {
+                  return Promise.resolve();
                 }
               })
             }


### PR DESCRIPTION
Hi guys, this introduces a middleware that can eventually validate that a related aggregate exists when issuing a command.

I'd like to discuss the name of the option `rejectWhenIdMissing`. The intention is clear but that doesn't sound good.

Let me know also if anything needs to be improved in the documentation.